### PR TITLE
Made CachingPublicKeysLoader private.

### DIFF
--- a/firebase_auth_token_validation/e2e_test/firebase_authentication_token_validator_test.dart
+++ b/firebase_auth_token_validation/e2e_test/firebase_authentication_token_validator_test.dart
@@ -48,7 +48,7 @@ void main() {
     httpClient = CountingHttpClient();
     validator = FirebaseAuthTokenValidator(
       firebaseProjectId: projectId,
-      publicKeysLoader: CachingPublicKeysLoader.retrying(inner: httpClient),
+      inner: httpClient,
     );
   });
 

--- a/firebase_auth_token_validation/lib/firebase_auth_token_validation.dart
+++ b/firebase_auth_token_validation/lib/firebase_auth_token_validation.dart
@@ -1,3 +1,3 @@
 library firebase_auth_token_validation;
 
-export 'src/firebase_auth_token_validator.dart';
+export 'src/firebase_auth_token_validator.dart' show FirebaseAuthTokenValidator;

--- a/firebase_auth_token_validation/lib/src/caching_public_keys_loader.dart
+++ b/firebase_auth_token_validation/lib/src/caching_public_keys_loader.dart
@@ -1,0 +1,107 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http_retry/http_retry.dart';
+import 'package:logging/logging.dart';
+import 'package:pointycastle/pointycastle.dart';
+import 'package:http/http.dart' as http;
+import 'package:meta/meta.dart';
+
+import 'jwt_validation_utils.dart';
+import 'firebase_auth_token_validator.dart';
+
+class CachingPublicKeysLoader {
+  CachingPublicKeysLoader({
+    @required this.client,
+    @required this.publicKeysUrl,
+    DateTime Function() getCurrentTime,
+  }) {
+    _getCurrentTime = getCurrentTime ?? () => DateTime.now();
+    _logger = Logger('$runtimeType');
+  }
+
+  factory CachingPublicKeysLoader.retrying({
+    http.Client inner,
+    String url,
+  }) {
+    return CachingPublicKeysLoader(
+      client: RetryClient(
+        inner ?? http.Client(),
+        when: (res) =>
+            res.statusCode == HttpStatus.internalServerError ||
+            res.statusCode == HttpStatus.serviceUnavailable,
+      ),
+      publicKeysUrl: url ?? googleKeyIdsUrl,
+    );
+  }
+
+  final http.Client client;
+  DateTime Function() _getCurrentTime;
+  Logger _logger;
+
+  /// URL containing the public keys for the Google certs (whose private keys are used to sign Firebase
+  /// Auth ID tokens)
+  final String publicKeysUrl;
+  var _cached = <String, RSAPublicKey>{};
+  DateTime _cachedOn;
+  Duration _validFor;
+  bool get _stillValid => _getCurrentTime().isBefore(_validTill);
+  DateTime get _validTill => _cachedOn.add(_validFor);
+
+  /// Gibt eine Map zurück, welche als Schlüssel die JWT-"kid"s und als Werte
+  /// die vom Zertifikat geparsten Public Keys hat.
+  /// Die Werte werden beim Aufrufen von der URL nach "max-age" im
+  /// "cache-control" header gecached (keine Library, die das automatisch macht
+  /// gefunden). Falls kein "cache-control" oder "max-age" vorhanden ist, dann
+  /// wird jedes mal die URL kontaktiert.
+  Future<Map<String, RSAPublicKey>> getPublicKeys() async {
+    if (_cached.isNotEmpty && _stillValid) {
+      return _cached;
+    }
+
+    final res = await client.get(publicKeysUrl);
+    if (res.statusCode != 200) {
+      // retry?
+      throw Exception(
+          'Could not parse public keys, got status code ${res.statusCode}.');
+    }
+
+    if (res.body == null || res.body.isEmpty) {
+      throw Exception('Could not parse public keys, got empty body.');
+    }
+
+    final parsedBody = json.decode(res.body) as Map<String, dynamic>;
+    final casted = parsedBody.cast<String, String>();
+    final keys = casted.map(
+      (kid, pemString) => MapEntry<String, RSAPublicKey>(
+        kid,
+        parsePublicKeyFromX509CertificateString(pemString),
+      ),
+    );
+
+    try {
+      final cacheControlHeader = res.headers[HttpHeaders.cacheControlHeader];
+      final maxAgeDuration = _parseMaxAge(cacheControlHeader);
+      _cached = keys;
+      _cachedOn = _getCurrentTime();
+      _validFor = maxAgeDuration;
+    } catch (e, s) {
+      _logger.warning('Could not cache public keys', e, s);
+    }
+
+    return keys;
+  }
+
+  Duration _parseMaxAge(String cacheControlHeader) {
+    final cacheControlHeaderParts = cacheControlHeader.split(' ');
+    String maxAgePart =
+        cacheControlHeaderParts.firstWhere((part) => part.contains('max-age='));
+    if (maxAgePart.contains(',')) {
+      maxAgePart = maxAgePart.replaceAll(',', '');
+    }
+    final maxAgeInSeconds =
+        maxAgePart.substring(maxAgePart.lastIndexOf('=') + 1);
+    final maxAgeDuration = Duration(seconds: int.parse(maxAgeInSeconds));
+    return maxAgeDuration;
+  }
+}

--- a/firebase_auth_token_validation/lib/src/firebase_auth_token_validator.dart
+++ b/firebase_auth_token_validation/lib/src/firebase_auth_token_validator.dart
@@ -1,49 +1,38 @@
 import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
 
 import 'package:corsac_jwt/corsac_jwt.dart';
-import 'package:http/http.dart' as http;
-import 'package:http_retry/http_retry.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:pointycastle/export.dart';
+import 'package:http/http.dart' as http;
 
 import 'jwt_validation_utils.dart';
+import 'caching_public_keys_loader.dart';
 
 /// URL containing the public keys for the Google certs (whose private keys are used to sign Firebase
 /// Auth ID tokens)
-const _googleKeyIdsUrl =
+const googleKeyIdsUrl =
     'https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com';
-
-bool isNotEmptyOrNull(String s) {
-  return s != null && s.isNotEmpty;
-}
-
-class Constraint {
-  Constraint(this.description, this.isSatisfiedBy);
-
-  final FutureOr<bool> Function(JWT jwt) isSatisfiedBy;
-  final String description;
-}
 
 /// See https://firebase.google.com/docs/auth/admin/verify-id-tokens#verify_id_tokens_using_a_third-party_jwt_library
 class FirebaseAuthTokenValidator {
-  FirebaseAuthTokenValidator(
-      {@required this.firebaseProjectId, this.publicKeysLoader}) {
-    if (!isNotEmptyOrNull(firebaseProjectId)) {
+  FirebaseAuthTokenValidator({
+    @required this.firebaseProjectId,
+    http.Client inner,
+  }) : _publicKeysLoader = CachingPublicKeysLoader.retrying(inner: inner) {
+    if (!_isNotEmptyOrNull(firebaseProjectId)) {
       throw ArgumentError('projectId muste be non-empty');
     }
-    jwtConstraints = <Constraint>[
+    _jwtConstraints = <Constraint>[
       Constraint('Algorithm is RS256', (jwt) => jwt.algorithm == 'RS256'),
       Constraint(
         'Contains non-empty "kid" header claim',
-        (jwt) => isNotEmptyOrNull(jwt.kidHeader),
+        (jwt) => _isNotEmptyOrNull(jwt.kidHeader),
       ),
       Constraint('Contains non-empty "sub" header claim (equals the uid)',
-          (jwt) => isNotEmptyOrNull(jwt.subject)),
+          (jwt) => _isNotEmptyOrNull(jwt.subject)),
       Constraint('Contains non-empty "auth_time" header claim',
-          (jwt) => isNotEmptyOrNull(jwt.kidHeader)),
+          (jwt) => _isNotEmptyOrNull(jwt.kidHeader)),
       Constraint(
           'Expiration time "exp" must be in the future. The time is measured in seconds since the UNIX epoch.',
           (jwt) => jwt.expiresAt.toDateTime().isAfter(DateTime.now())),
@@ -60,9 +49,9 @@ class FirebaseAuthTokenValidator {
       Constraint('Authentication time "auth_time" must be in the past.',
           (jwt) => jwt.authTime.toDateTime().isBefore(DateTime.now())),
       Constraint(
-        'Key ID "kid" header claim must be signed by one of the public keys listed at $_googleKeyIdsUrl.',
+        'Key ID "kid" header claim must be signed by one of the public keys listed at $googleKeyIdsUrl.',
         (jwt) async {
-          final publicKeys = await publicKeysLoader.getPublicKeys();
+          final publicKeys = await _publicKeysLoader.getPublicKeys();
           final matchingKid =
               publicKeys.keys.where((key) => key == jwt.kidHeader).first;
           if (matchingKid.isEmpty) {
@@ -78,16 +67,16 @@ class FirebaseAuthTokenValidator {
     _logger = Logger('$runtimeType');
   }
 
-  List<Constraint> jwtConstraints;
+  List<Constraint> _jwtConstraints;
   final String firebaseProjectId;
-  final CachingPublicKeysLoader publicKeysLoader;
+  final CachingPublicKeysLoader _publicKeysLoader;
   Logger _logger;
 
   /// Returns claims
   Future<Map<String, dynamic>> validateJwt(String encodedJwt) async {
     final jwt = JWT.parse(encodedJwt);
     _logger.finer('Successfully parsed JWT');
-    for (final constraint in jwtConstraints) {
+    for (final constraint in _jwtConstraints) {
       final satisfied = await constraint.isSatisfiedBy(jwt);
       _logger.finer(
           'JWT-Token constraint ${constraint.description} satisfied: $satisfied');
@@ -101,100 +90,15 @@ class FirebaseAuthTokenValidator {
   }
 }
 
-class CachingPublicKeysLoader {
-  CachingPublicKeysLoader({
-    @required this.client,
-    @required this.googleKeyIdsUrl,
-    DateTime Function() getCurrentTime,
-  }) {
-    _getCurrentTime = getCurrentTime ?? () => DateTime.now();
-    _logger = Logger('$runtimeType');
-  }
+class Constraint {
+  Constraint(this.description, this.isSatisfiedBy);
 
-  factory CachingPublicKeysLoader.retrying({
-    http.Client inner,
-    String url,
-  }) {
-    return CachingPublicKeysLoader(
-      client: RetryClient(
-        inner ?? http.Client(),
-        when: (res) =>
-            res.statusCode == HttpStatus.internalServerError ||
-            res.statusCode == HttpStatus.serviceUnavailable,
-      ),
-      googleKeyIdsUrl: url ?? _googleKeyIdsUrl,
-    );
-  }
+  final FutureOr<bool> Function(JWT jwt) isSatisfiedBy;
+  final String description;
+}
 
-  final http.Client client;
-  DateTime Function() _getCurrentTime;
-  Logger _logger;
-
-  /// URL containing the public keys for the Google certs (whose private keys are used to sign Firebase
-  /// Auth ID tokens)
-  final String googleKeyIdsUrl;
-  var _cached = <String, RSAPublicKey>{};
-  DateTime _cachedOn;
-  Duration _validFor;
-  bool get _stillValid => _getCurrentTime().isBefore(_validTill);
-  DateTime get _validTill => _cachedOn.add(_validFor);
-
-  /// Gibt eine Map zurück, welche als Schlüssel die JWT-"kid"s und als Werte
-  /// die vom Zertifikat geparsten Public Keys hat.
-  /// Die Werte werden beim Aufrufen von der URL nach "max-age" im
-  /// "cache-control" header gecached (keine Library, die das automatisch macht
-  /// gefunden). Falls kein "cache-control" oder "max-age" vorhanden ist, dann
-  /// wird jedes mal die URL kontaktiert.
-  Future<Map<String, RSAPublicKey>> getPublicKeys() async {
-    if (_cached.isNotEmpty && _stillValid) {
-      return _cached;
-    }
-
-    final res = await client.get(googleKeyIdsUrl);
-    if (res.statusCode != 200) {
-      // retry?
-      throw Exception(
-          'Could not parse public keys, got status code ${res.statusCode}.');
-    }
-
-    if (res.body == null || res.body.isEmpty) {
-      throw Exception('Could not parse public keys, got empty body.');
-    }
-
-    final parsedBody = json.decode(res.body) as Map<String, dynamic>;
-    final casted = parsedBody.cast<String, String>();
-    final keys = casted.map(
-      (kid, pemString) => MapEntry<String, RSAPublicKey>(
-        kid,
-        parsePublicKeyFromX509CertificateString(pemString),
-      ),
-    );
-
-    try {
-      final cacheControlHeader = res.headers[HttpHeaders.cacheControlHeader];
-      final maxAgeDuration = _parseMaxAge(cacheControlHeader);
-      _cached = keys;
-      _cachedOn = _getCurrentTime();
-      _validFor = maxAgeDuration;
-    } catch (e, s) {
-      _logger.warning('Could not cache public keys', e, s);
-    }
-
-    return keys;
-  }
-
-  Duration _parseMaxAge(String cacheControlHeader) {
-    final cacheControlHeaderParts = cacheControlHeader.split(' ');
-    String maxAgePart =
-        cacheControlHeaderParts.firstWhere((part) => part.contains('max-age='));
-    if (maxAgePart.contains(',')) {
-      maxAgePart = maxAgePart.replaceAll(',', '');
-    }
-    final maxAgeInSeconds =
-        maxAgePart.substring(maxAgePart.lastIndexOf('=') + 1);
-    final maxAgeDuration = Duration(seconds: int.parse(maxAgeInSeconds));
-    return maxAgeDuration;
-  }
+bool _isNotEmptyOrNull(String s) {
+  return s != null && s.isNotEmpty;
 }
 
 extension on JWT {

--- a/firebase_auth_token_validation/test/public_keys_loader_test.dart
+++ b/firebase_auth_token_validation/test/public_keys_loader_test.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 
-import 'package:firebase_auth_token_validation/firebase_auth_token_validation.dart';
 import 'package:firebase_auth_token_validation/src/jwt_validation_utils.dart'
     as validation;
+import 'package:firebase_auth_token_validation/src/caching_public_keys_loader.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart' as http;
 import 'package:test/test.dart';
@@ -18,7 +18,7 @@ void main() {
       httpClient = http.MockClient((r) => handler(r));
       publicKeysLoader = CachingPublicKeysLoader(
         client: httpClient,
-        googleKeyIdsUrl: 'https://www.some-url.com',
+        publicKeysUrl: 'https://www.some-url.com',
         getCurrentTime: () => getCurrentTime(),
       );
       getCurrentTime = () => DateTime.now();


### PR DESCRIPTION
Also:
* Library now only exports FirebaseAuthTokenValidator
* FirebaseAuthTokenValidator has now private attributes except firebaseProjectId
* publicKeysLoader can't be passed to FirebaseAuthTokenValidator anymore as I'm not yet sure that this is necessary for users and don't want to risk breaking changes in the future yet
