### PR TITLE
Fixed spacing in bash if condition.

### DIFF
--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -2,7 +2,7 @@
 set -e
 
 # On CI-Pipeline env-vars are pre-exported via Github secrets not via .env file.
-if [-f ".env"]; then
+if [ -f ".env" ]; then
     # Must be ". script" so that vars are exported to this shell
     . ./load_env_into_bash.sh
 fi


### PR DESCRIPTION
The spacing gave the error "[-f: command not found" which means that the .env would not be read.
