### PR TITLE
ci: set Dart version to 2.10.0

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -10,7 +10,7 @@ jobs:
   check-no-lints-and-todos:
     runs-on: ubuntu-latest
     container:
-      image:  google/dart:latest
+      image:  google/dart:2.10.0
     steps:
     - uses: actions/checkout@v2
     - name: Check for lint Errors
@@ -19,7 +19,7 @@ jobs:
   is-formatted:
     runs-on: ubuntu-latest
     container:
-      image:  google/dart:latest
+      image:  google/dart:2.10.0
     steps:
     - uses: actions/checkout@v2
     - name: Check for lint Errors
@@ -28,7 +28,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image:  google/dart:latest
+      image:  google/dart:2.10.0
     steps:
     - uses: actions/checkout@v2
     - name: Run tests


### PR DESCRIPTION
Currently, the ci pipeline is failing, because the dart version too new for the dart packages:
* https://github.com/SharezoneApp/firebase_auth_token_validation/actions/runs/1290757255

With this PR we are using a hard coded Dart version, so that the ci pipeline does not fail for random reasons.