### PR TITLE
Update `actions/checkout` from v2 to v3 in our GitHub workflows

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -12,7 +12,7 @@ jobs:
     container:
       image:  google/dart:2.10.0
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check for lint Errors
       run: ./check_for_lint_errors_and_TODO_comments.sh
 
@@ -21,7 +21,7 @@ jobs:
     container:
       image:  google/dart:2.10.0
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check for lint Errors
       run: ./check_code_is_formatted.sh
 
@@ -30,7 +30,7 @@ jobs:
     container:
       image:  google/dart:2.10.0
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run tests
       env:
         FIREBASE_FUNCTIONS_BASE_URL: ${{ secrets.FIREBASE_FUNCTIONS_BASE_URL }}


### PR DESCRIPTION
Node 12 is deprecated for GitHub Actions. This is the reason why we are getting a warning from GitHub:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

This PR updates `actions/checkout` from v2 to v3 which should fix the problem.